### PR TITLE
Remove re-beautify

### DIFF
--- a/tasks/jsbeautifier.js
+++ b/tasks/jsbeautifier.js
@@ -19,8 +19,6 @@ module.exports = function(grunt) {
 
         grunt.file.expand(files).forEach(function(filepath) {
             var result = beautify(grunt.file.read(filepath), tmp_opts);
-            // Had to re-beautify for weired issue of block comment.
-            result = beautify(result, tmp_opts);
 
             // ensure newline at end of beautified output
             result += '\n';


### PR DESCRIPTION
This line means the grunt task runs beautify twice on every file. 
For such a significant perf hit, we should have an open issue with
clear description and repro steps both in this project
and in einars/jsbeautifier.  Otherwise we should remove this. 
