### PR TITLE
Add verify_beautification option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,24 @@ module.exports = function(grunt) {
     // Project configuration.
     grunt.initConfig({
         jsbeautifier: {
-            files: ['package.json', '<%= jshint.files %>']
+            default: {
+                src: ['package.json', '<%= jshint.files %>']
+            },
+            has_not_been_beautified: {
+                src: ['test/fixtures/not-been-beautified.js'],
+                options: {
+                    verify_beautification: true
+                }
+            },
+            has_been_beautified: {
+                src: ['test/fixtures/been-beautified.js'],
+                options: {
+                    verify_beautification: true
+                }
+            },
+            options: {
+                indent_size: 4
+            }
         },
         nodeunit: {
             all: ['test/**/*.js']
@@ -35,6 +52,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
     // By default, beautifiy, lint and run all tests.
-    grunt.registerTask('default', ['jsbeautifier', 'jshint', 'nodeunit']);
+    grunt.registerTask('default', ['jsbeautifier:default', 'jshint', 'nodeunit']);
 
 };

--- a/tasks/jsbeautifier.js
+++ b/tasks/jsbeautifier.js
@@ -24,9 +24,17 @@ module.exports = function(grunt) {
                 var result = beautify(original, params);
                 result += '\n';
                 grunt.verbose.ok();
-                if (original !== result) {
-                    grunt.file.write(src, result);
-                    changedFileCount++;
+                if (params.verify_beautification) {
+                    if (original !== result) {
+                        grunt.fail.warn(src.cyan + ' was not beautified');
+                    }
+
+                } else {
+                    if (original !== result) {
+                        grunt.file.write(src, result);
+                        changedFileCount++;
+                    }
+
                 }
                 fileCount++;
             });

--- a/test/fixtures/been-beautified.js
+++ b/test/fixtures/been-beautified.js
@@ -1,0 +1,4 @@
+var temp = {
+    hello: 1,
+    world: 2
+}

--- a/test/fixtures/not-been-beautified.js
+++ b/test/fixtures/not-been-beautified.js
@@ -1,0 +1,4 @@
+var temp = {
+ hello: 1,
+world: 2
+}

--- a/test/jsbeautifier_test.js
+++ b/test/jsbeautifier_test.js
@@ -1,5 +1,6 @@
 "use strict";
 var grunt = require('grunt');
+var exec = require('child_process').exec;
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -26,11 +27,26 @@ exports['jsbeautifier'] = {
         // setup here
         done();
     },
-    'helper': function(test) {
+    'Verify beautification with unbeautified file': function(test) {
         test.expect(1);
-        // tests here
-        // test.equal(grunt.helper('jsbeautifier'), 'jsbeautifier!!!', 'should return the correct value.');
-        test.equal(true, true);
-        test.done();
+        exec('grunt jsbeautifier:has_not_been_beautified', {
+                cwd: __dirname + '/../'
+            },
+            function(err, stdout, stderr) {
+                test.notEqual(err, null, 'Grunt fails because file has not been beautified');
+                test.done();
+            });
+
+    },
+    'Verify beautification with beautified file': function(test) {
+        test.expect(1);
+        exec('grunt jsbeautifier:has_been_beautified', {
+                cwd: __dirname + '/../'
+            },
+            function(err, stdout, stderr) {
+                test.equal(err, null, 'Grunt passes because file has been beautified');
+                test.done();
+            });
+
     }
 };


### PR DESCRIPTION
I would like to use this to verify that beautification has happened, rather than mutate a file in place. I can then add this into my build/pre-commit process to reject commits that haven't been beautified. 

I've also added tests into this plugin that can be run using `grunt nodeunit`.  
