### PR TITLE
Updating grunt dependency on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "async": "^2.0.0-rc.3",
-        "grunt": "^0.4.1",
+        "grunt": ">=0.4.1",
         "js-beautify": ">=1.4.2",
         "lodash": ">=2.4.1",
         "rc": ">=0.5.5",


### PR DESCRIPTION
Trying to support Grunt version 1.x and above.

This single change should allow the usage 

In my environment works ok, but additional testing should be performed. And should be evaluated also the version of grunt-contrib-\* packages in devDependencies (currently it's `^1.0.0`).
